### PR TITLE
Fix background proportions

### DIFF
--- a/src/components/styles/ABTClasses.css
+++ b/src/components/styles/ABTClasses.css
@@ -1,6 +1,6 @@
 .schedule-container {
   background: url('../../images/site/schedule.jpg') no-repeat fixed;
-  background-size: 500px 100%;
+  background-size: auto 100%;
   width: 100vw;
   margin: 0 auto;
   display: inline-table;


### PR DESCRIPTION
Hey Altamir,

I think the simplest fix for the background sizing issue is to just set the 500px to auto.  If image sizes get too random you can then just crop the actual image files all to the same ratio so "auto" would be consistent throughout.

If you want it to be a little more flexible to whatever image you drop in, or have more control over width of the image on the screen, you really need a dedicated container to apply the background image to instead of that full width container.  Then just float that container left, set to be 100vh and whatever % width you want the image to be.  And then give the background image just "background-size: cover, background-attachment: fixed". 

Hope that all makes sense, shoot me an email if not - rg@geisleryoung.com    We rarely use git so I'm a little out of my element in the interface.

Rich